### PR TITLE
fix for mingw: undefined symbol WinMain

### DIFF
--- a/src/imrad.cpp
+++ b/src/imrad.cpp
@@ -1955,7 +1955,7 @@ std::string GetRootPath()
 #endif
 }
 
-#ifdef WIN32
+#if (WIN32) && !(__MINGW32__)
 int WINAPI wWinMain(
     HINSTANCE   hInstance,
     HINSTANCE   hPrevInstance,


### PR DESCRIPTION
I use clang64 from msys2
small fix for problem "undefined symbol: WinMain" on mingw family compilers 
