### PR TITLE
Built-in Style Editor

### DIFF
--- a/src/imrad.cpp
+++ b/src/imrad.cpp
@@ -1152,6 +1152,7 @@ void DockspaceUI()
         ImGui::DockBuilderDockWindow("Hierarchy", dock_id_left);
         ImGui::DockBuilderDockWindow("Explorer", dock_id_left);
         ImGui::DockBuilderDockWindow("Widgets", dock_id_right1);
+        ImGui::DockBuilderDockWindow("Style Editor", dock_id_right2);
         ImGui::DockBuilderDockWindow("Properties", dock_id_right2);
         ImGui::DockBuilderDockWindow("Events", dock_id_right2);
         ImGui::DockBuilderFinish(dockspace_id);

--- a/src/imrad.cpp
+++ b/src/imrad.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #if WIN32
 #define WIN32_LEAN_AND_MEAN
 #include <Windows.h>
@@ -528,6 +529,9 @@ void CloseFile(int flags)
 
 void DoSaveFile(int flags)
 {
+    auto stit = stx::find_if(styleNames, [&](auto& st) { return st.first == styleName; });
+    if (!stit->second.empty()) ImRad::SaveStyle(stit->second, &ctx.style);
+
     GLFWmonitor* monitor = glfwGetPrimaryMonitor();
     const GLFWvidmode* mode = glfwGetVideoMode(monitor);
     int width_mm, height_mm;

--- a/src/imrad.cpp
+++ b/src/imrad.cpp
@@ -1817,7 +1817,15 @@ void PropertyRowsUI(int pr)
                 ImGui::TableSetColumnIndex(0);
                 ImGui::AlignTextToFramePadding();
             }
-            bool change = pr == 2 ? ctx.selected[0]->StyleUI(i, ctx) : pr ? ctx.selected[0]->PropertyUI(i, ctx) : ctx.selected[0]->EventUI(i, ctx);
+            bool change;
+            if (pr == 2)
+            {
+                ImGui::BeginDisabled(!styleCanBeEdited);
+                change = ctx.selected[0]->StyleUI(i, ctx);
+                ImGui::EndDisabled();
+            }
+            else
+                change = pr ? ctx.selected[0]->PropertyUI(i, ctx) : ctx.selected[0]->EventUI(i, ctx);
             if (change) {
                 fileTabs[activeTab].modified = true;
                 if (props[i].property) {

--- a/src/imrad.cpp
+++ b/src/imrad.cpp
@@ -1,4 +1,3 @@
-#include <algorithm>
 #if WIN32
 #define WIN32_LEAN_AND_MEAN
 #include <Windows.h>

--- a/src/imrad.h
+++ b/src/imrad.h
@@ -13,6 +13,7 @@ before you include this file in *one* C++ file to create implementation.
 
 #include <string>
 #include <vector>
+#include <algorithm>
 #include <functional> //for ModalPopup callback
 #include <map>
 #include <imgui.h>

--- a/src/node_standard.cpp
+++ b/src/node_standard.cpp
@@ -1,7 +1,6 @@
 ﻿#include "node_standard.h"
 /**/#include "node_container.h"
 /**/#include "node_extra.h"
-#include "imgui.h"
 #include "stx.h"
 #include "cppgen.h"
 #include "binding_input.h"
@@ -3161,7 +3160,7 @@ bool UINode::StyleUI(int i, UIContext& ctx)
     switch (attributes[i].type)
     {
     case StyleDropdownVec2:
-        ImGui::Text("%d, %d", (int)((ImVec2*)attributes[i].value)->x, (int)((ImVec2*)attributes[i].value)->y);
+        ImGui::Text("%.3f, %.3f", ((ImVec2*)attributes[i].value)->x, ((ImVec2*)attributes[i].value)->y);
         break;
     case StyleColor:
         changed = ImGui::ColorEdit4(id.c_str(), (float*)attributes[i].value, ImGui::GetContentRegionAvail().x < 200 ? ImGuiColorEditFlags_NoInputs : 0);

--- a/src/node_standard.cpp
+++ b/src/node_standard.cpp
@@ -1,6 +1,7 @@
 ﻿#include "node_standard.h"
 /**/#include "node_container.h"
 /**/#include "node_extra.h"
+#include "imgui.h"
 #include "stx.h"
 #include "cppgen.h"
 #include "binding_input.h"
@@ -2863,6 +2864,35 @@ bool Widget::EventUI(int i, UIContext& ctx)
         break;
     default:
         return false;
+    }
+    return changed;
+}
+
+std::vector<UINode::Prop>
+UINode::Style(UIContext& ctx)
+{
+    return {
+        { "color.text", NULL },
+        { "color.textDisabled", NULL },
+    };
+}
+
+bool UINode::StyleUI(int i, UIContext& ctx)
+{
+    bool changed = false;
+    if (!i)
+    {
+        ImGui::Text("Text");
+        ImGui::TableNextColumn();
+        ImGui::SetNextItemWidth(-1);
+        changed = ImGui::ColorEdit4("##_ColorText", (float*)&ctx.style.Colors[ImGuiCol_Text]);
+    }
+    else
+    {
+        ImGui::Text("Disabled Text");
+        ImGui::TableNextColumn();
+        ImGui::SetNextItemWidth(-1);
+        changed = ImGui::ColorEdit4("##_ColorTextDisabled", (float*)&ctx.style.Colors[ImGuiCol_TextDisabled]);
     }
     return changed;
 }

--- a/src/node_standard.cpp
+++ b/src/node_standard.cpp
@@ -3161,9 +3161,7 @@ bool UINode::StyleUI(int i, UIContext& ctx)
     switch (attributes[i].type)
     {
     case StyleDropdownVec2:
-        ImGui::PushFont(true ? ctx.pgbFont : ctx.pgFont);
         ImGui::Text("%d, %d", (int)((ImVec2*)attributes[i].value)->x, (int)((ImVec2*)attributes[i].value)->y);
-        ImGui::PopFont();
         break;
     case StyleColor:
         changed = ImGui::ColorEdit4(id.c_str(), (float*)attributes[i].value, ImGui::GetContentRegionAvail().x < 200 ? ImGuiColorEditFlags_NoInputs : 0);

--- a/src/node_standard.cpp
+++ b/src/node_standard.cpp
@@ -2931,90 +2931,251 @@ UINode::Style(UIContext& ctx)
         { "color.navCursor", NULL },
         { "color.navWindowingHighlight", NULL },
         { "color.navWindowingDimBg", NULL },
-        { "color.modalWindowDimBg", NULL }
+        { "color.modalWindowDimBg", NULL },
+        { "style.alpha", NULL },
+        { "style.disabledAlpha", NULL },
+        { "style.windowPadding.summary", NULL },
+        { "style.windowPadding.windowPadding_x", NULL },
+        { "style.windowPadding.windowPadding_y", NULL },
+        { "style.windowRounding", NULL },
+        { "style.windowBorderSize", NULL },
+        { "style.windowMinSize.summary", NULL },
+        { "style.windowMinSize.windowMinSize_x", NULL },
+        { "style.windowMinSize.windowMinSize_y", NULL },
+        { "style.windowTitleAlign.summary", NULL },
+        { "style.windowTitleAlign.windowTitleAlign_x", NULL },
+        { "style.windowTitleAlign.windowTitleAlign_y", NULL },
+        { "style.childRounding", NULL },
+        { "style.childBorderSize", NULL },
+        { "style.popupRounding", NULL },
+        { "style.popupBorderSize", NULL },
+        { "style.framePadding.summary", NULL },
+        { "style.framePadding.framePadding_x", NULL },
+        { "style.framePadding.framePadding_y", NULL },
+        { "style.frameRounding", NULL },
+        { "style.frameBorderSize", NULL },
+        { "style.itemSpacing.summary", NULL },
+        { "style.itemSpacing.itemSpacing_x", NULL },
+        { "style.itemSpacing.itemSpacing_y", NULL },
+        { "style.itemInnerSpacing.summary", NULL },
+        { "style.itemInnerSpacing.itemInnerSpacing_x", NULL },
+        { "style.itemInnerSpacing.itemInnerSpacing_y", NULL },
+        { "style.cellPadding.summary", NULL },
+        { "style.cellPadding.cellPadding_x", NULL },
+        { "style.cellPadding.cellPadding_y", NULL },
+        { "style.touchExtraPadding.summary", NULL },
+        { "style.touchExtraPadding.touchExtraPadding_x", NULL },
+        { "style.touchExtraPadding.touchExtraPadding_y", NULL },
+        { "style.indentSpacing", NULL },
+        { "style.columnsMinSpacing", NULL },
+        { "style.scrollbarSize", NULL },
+        { "style.scrollbarRounding", NULL },
+        { "style.scrollbarPadding", NULL },
+        { "style.grabMinSize", NULL },
+        { "style.grabRounding", NULL },
+        { "style.imageBorderSize", NULL },
+        { "style.tabRounding", NULL },
+        { "style.tabBorderSize", NULL },
+        { "style.tabMinWidthBase", NULL },
+        { "style.tabMinWidthShrink", NULL },
+        { "style.tabCloseButtonMinWidthSelected", NULL },
+        { "style.tabCloseButtonMinWidthUnselected", NULL },
+        { "style.tabBarBorderSize", NULL },
+        { "style.tabBarOverlineSize", NULL },
+        { "style.treeLinesSize", NULL },
+        { "style.treeLinesRounding", NULL },
+        { "style.buttonTextAlign.summary", NULL },
+        { "style.buttonTextAlign.buttonTextAlign_x", NULL },
+        { "style.buttonTextAlign.buttonTextAlign_y", NULL },
+        { "style.selectableTextAlign.summary", NULL },
+        { "style.selectableTextAlign.selectableTextAlign_x", NULL },
+        { "style.selectableTextAlign.selectableTextAlign_y", NULL },
+        { "style.separatorTextBorderSize", NULL },
+        { "style.separatorTextAlign.summary", NULL },
+        { "style.separatorTextAlign.separatorTextAlign_x", NULL },
+        { "style.separatorTextAlign.separatorTextAlign_y", NULL },
+        { "style.separatorTextPadding.summary", NULL },
+        { "style.separatorTextPadding.separatorTextPadding_x", NULL },
+        { "style.separatorTextPadding.separatorTextPadding_y", NULL }
     };
 }
 
 bool UINode::StyleUI(int i, UIContext& ctx)
 {
     bool changed = false;
-    
-    // Name & ID
-    const char* names[] = {
-        "Text",
-        "TextDisabled",
-        "WindowBg",
-        "ChildBg",
-        "PopupBg",
-        "Border",
-        "BorderShadow",
-        "FrameBg",
-        "FrameBgHovered",
-        "FrameBgActive",
-        "TitleBg",
-        "TitleBgActive",
-        "TitleBgCollapsed",
-        "MenuBarBg",
-        "ScrollbarBg",
-        "ScrollbarGrab",
-        "ScrollbarGrabHovered",
-        "ScrollbarGrabActive",
-        "CheckMark",
-        "SliderGrab",
-        "SliderGrabActive",
-        "Button",
-        "ButtonHovered",
-        "ButtonActive",
-        "Header",
-        "HeaderHovered",
-        "HeaderActive",
-        "Separator",
-        "SeparatorHovered",
-        "SeparatorActive",
-        "ResizeGrip",
-        "ResizeGripHovered",
-        "ResizeGripActive",
-        "InputTextCursor",
-        "TabHovered",
-        "Tab",
-        "TabSelected",
-        "TabSelectedOverline",
-        "TabDimmed",
-        "TabDimmedSelected",
-        "TabDimmedSelectedOverline",
-        "DockingPreview",
-        "DockingEmptyBg",
-        "PlotLines",
-        "PlotLinesHovered",
-        "PlotHistogram",
-        "PlotHistogramHovered",
-        "TableHeaderBg",
-        "TableBorderStrong",
-        "TableBorderLight",
-        "TableRowBg",
-        "TableRowBgAlt",
-        "TextLink",
-        "TextSelectedBg",
-        "TreeLines",
-        "DragDropTarget",
-        "NavCursor",
-        "NavWindowingHighlight",
-        "NavWindowingDimBg",
-        "ModalWindowDimBg",
+
+    enum StyleType : uint8_t {
+        StyleInvalid,
+        StyleColor,
+        StyleDropdownColor,
+        StyleFloat,
+        StyleDropdownVec2,
+        StyleYesNo, // Float drag that only accepts 0/1
     };
-    std::string id = "##_" + std::string(names[i]);
+
+    struct StyleAttribute {
+        const char* name;
+        StyleType type;
+        void* value;
+        float min = -100.f;
+        float max = 100.f;
+    };
+    
+    // Attributes
+    StyleAttribute attributes[] = {
+        { "Text", StyleColor, &ctx.style.Colors[ImGuiCol_Text] },
+        { "TextDisabled", StyleColor, &ctx.style.Colors[ImGuiCol_TextDisabled] },
+        { "WindowBg", StyleColor, &ctx.style.Colors[ImGuiCol_WindowBg] },
+        { "ChildBg", StyleColor, &ctx.style.Colors[ImGuiCol_ChildBg] },
+        { "PopupBg", StyleColor, &ctx.style.Colors[ImGuiCol_PopupBg] },
+        { "Border", StyleColor, &ctx.style.Colors[ImGuiCol_Border] },
+        { "BorderShadow", StyleColor, &ctx.style.Colors[ImGuiCol_BorderShadow] },
+        { "FrameBg", StyleColor, &ctx.style.Colors[ImGuiCol_FrameBg] },
+        { "FrameBgHovered", StyleColor, &ctx.style.Colors[ImGuiCol_FrameBgHovered] },
+        { "FrameBgActive", StyleColor, &ctx.style.Colors[ImGuiCol_FrameBgActive] },
+        { "TitleBg", StyleColor, &ctx.style.Colors[ImGuiCol_TitleBg] },
+        { "TitleBgActive", StyleColor, &ctx.style.Colors[ImGuiCol_TitleBgActive] },
+        { "TitleBgCollapsed", StyleColor, &ctx.style.Colors[ImGuiCol_TitleBgCollapsed] },
+        { "MenuBarBg", StyleColor, &ctx.style.Colors[ImGuiCol_MenuBarBg] },
+        { "ScrollbarBg", StyleColor, &ctx.style.Colors[ImGuiCol_ScrollbarBg] },
+        { "ScrollbarGrab", StyleColor, &ctx.style.Colors[ImGuiCol_ScrollbarGrab] },
+        { "ScrollbarGrabHovered", StyleColor, &ctx.style.Colors[ImGuiCol_ScrollbarGrabHovered] },
+        { "ScrollbarGrabActive", StyleColor, &ctx.style.Colors[ImGuiCol_ScrollbarGrabActive] },
+        { "CheckMark", StyleColor, &ctx.style.Colors[ImGuiCol_CheckMark] },
+        { "SliderGrab", StyleColor, &ctx.style.Colors[ImGuiCol_SliderGrab] },
+        { "SliderGrabActive", StyleColor, &ctx.style.Colors[ImGuiCol_SliderGrabActive] },
+        { "Button", StyleColor, &ctx.style.Colors[ImGuiCol_Button] },
+        { "ButtonHovered", StyleColor, &ctx.style.Colors[ImGuiCol_ButtonHovered] },
+        { "ButtonActive", StyleColor, &ctx.style.Colors[ImGuiCol_ButtonActive] },
+        { "Header", StyleColor, &ctx.style.Colors[ImGuiCol_Header] },
+        { "HeaderHovered", StyleColor, &ctx.style.Colors[ImGuiCol_HeaderHovered] },
+        { "HeaderActive", StyleColor, &ctx.style.Colors[ImGuiCol_HeaderActive] },
+        { "Separator", StyleColor, &ctx.style.Colors[ImGuiCol_Separator] },
+        { "SeparatorHovered", StyleColor, &ctx.style.Colors[ImGuiCol_SeparatorHovered] },
+        { "SeparatorActive", StyleColor, &ctx.style.Colors[ImGuiCol_SeparatorActive] },
+        { "ResizeGrip", StyleColor, &ctx.style.Colors[ImGuiCol_ResizeGrip] },
+        { "ResizeGripHovered", StyleColor, &ctx.style.Colors[ImGuiCol_ResizeGripHovered] },
+        { "ResizeGripActive", StyleColor, &ctx.style.Colors[ImGuiCol_ResizeGripActive] },
+        { "InputTextCursor", StyleColor, &ctx.style.Colors[ImGuiCol_InputTextCursor] },
+        { "TabHovered", StyleColor, &ctx.style.Colors[ImGuiCol_TabHovered] },
+        { "Tab", StyleColor, &ctx.style.Colors[ImGuiCol_Tab] },
+        { "TabSelected", StyleColor, &ctx.style.Colors[ImGuiCol_TabSelected] },
+        { "TabSelectedOverline", StyleColor, &ctx.style.Colors[ImGuiCol_TabSelectedOverline] },
+        { "TabDimmed", StyleColor, &ctx.style.Colors[ImGuiCol_TabDimmed] },
+        { "TabDimmedSelected", StyleColor, &ctx.style.Colors[ImGuiCol_TabDimmedSelected] },
+        { "TabDimmedSelectedOverline", StyleColor, &ctx.style.Colors[ImGuiCol_TabDimmedSelectedOverline] },
+        { "DockingPreview", StyleColor, &ctx.style.Colors[ImGuiCol_DockingPreview] },
+        { "DockingEmptyBg", StyleColor, &ctx.style.Colors[ImGuiCol_DockingEmptyBg] },
+        { "PlotLines", StyleColor, &ctx.style.Colors[ImGuiCol_PlotLines] },
+        { "PlotLinesHovered", StyleColor, &ctx.style.Colors[ImGuiCol_PlotLinesHovered] },
+        { "PlotHistogram", StyleColor, &ctx.style.Colors[ImGuiCol_PlotHistogram] },
+        { "PlotHistogramHovered", StyleColor, &ctx.style.Colors[ImGuiCol_PlotHistogramHovered] },
+        { "TableHeaderBg", StyleColor, &ctx.style.Colors[ImGuiCol_TableHeaderBg] },
+        { "TableBorderStrong", StyleColor, &ctx.style.Colors[ImGuiCol_TableBorderStrong] },
+        { "TableBorderLight", StyleColor, &ctx.style.Colors[ImGuiCol_TableBorderLight] },
+        { "TableRowBg", StyleColor, &ctx.style.Colors[ImGuiCol_TableRowBg] },
+        { "TableRowBgAlt", StyleColor, &ctx.style.Colors[ImGuiCol_TableRowBgAlt] },
+        { "TextLink", StyleColor, &ctx.style.Colors[ImGuiCol_TextLink] },
+        { "TextSelectedBg", StyleColor, &ctx.style.Colors[ImGuiCol_TextSelectedBg] },
+        { "TreeLines", StyleColor, &ctx.style.Colors[ImGuiCol_TreeLines] },
+        { "DragDropTarget", StyleColor, &ctx.style.Colors[ImGuiCol_DragDropTarget] },
+        { "NavCursor", StyleColor, &ctx.style.Colors[ImGuiCol_NavCursor] },
+        { "NavWindowingHighlight", StyleColor, &ctx.style.Colors[ImGuiCol_NavWindowingHighlight] },
+        { "NavWindowingDimBg", StyleColor, &ctx.style.Colors[ImGuiCol_NavWindowingDimBg] },
+        { "ModalWindowDimBg", StyleColor, &ctx.style.Colors[ImGuiCol_ModalWindowDimBg] },
+        { "Alpha", StyleFloat, &ctx.style.Alpha, 0, 1 },
+        { "DisabledAlpha", StyleFloat, &ctx.style.DisabledAlpha, 0, 1 },
+        { "WindowPadding", StyleDropdownVec2, &ctx.style.WindowPadding },
+            { "WindowPadding.x", StyleFloat, &ctx.style.WindowPadding.x, 0 },
+            { "WindowPadding.y", StyleFloat, &ctx.style.WindowPadding.y, 0 },
+        { "WindowRounding", StyleFloat, &ctx.style.WindowRounding, 0 },
+        { "WindowBorderSize", StyleYesNo, &ctx.style.WindowBorderSize },
+        { "WindowMinSize", StyleDropdownVec2, &ctx.style.WindowMinSize },
+            { "WindowMinSize.x", StyleFloat, &ctx.style.WindowMinSize.x, 0 },
+            { "WindowMinSize.y", StyleFloat, &ctx.style.WindowMinSize.y, 0 },
+        { "WindowTitleAlign", StyleDropdownVec2, &ctx.style.WindowTitleAlign },
+            { "WindowTitleAlign.x", StyleFloat, &ctx.style.WindowTitleAlign.x, 0, 1 },
+            { "WindowTitleAlign.y", StyleFloat, &ctx.style.WindowTitleAlign.y, 0, 1 },
+        { "ChildRounding", StyleFloat, &ctx.style.ChildRounding, 0 },
+        { "ChildBorderSize", StyleYesNo, &ctx.style.ChildBorderSize },
+        { "PopupRounding", StyleFloat, &ctx.style.PopupRounding, 0 },
+        { "PopupBorderSize", StyleYesNo, &ctx.style.PopupBorderSize },
+        { "FramePadding", StyleDropdownVec2, &ctx.style.FramePadding },
+            { "FramePadding.x", StyleFloat, &ctx.style.FramePadding.x, 0 },
+            { "FramePadding.y", StyleFloat, &ctx.style.FramePadding.y, 0 },
+        { "FrameRounding", StyleFloat, &ctx.style.FrameRounding, 0 },
+        { "FrameBorderSize", StyleYesNo, &ctx.style.FrameBorderSize },
+        { "ItemSpacing", StyleDropdownVec2, &ctx.style.ItemSpacing, 0 },
+            { "ItemSpacing.x", StyleFloat, &ctx.style.ItemSpacing.x, 0 },
+            { "ItemSpacing.y", StyleFloat, &ctx.style.ItemSpacing.y, 0 },
+        { "ItemInnerSpacing", StyleDropdownVec2, &ctx.style.ItemInnerSpacing },
+            { "ItemInnerSpacing.x", StyleFloat, &ctx.style.ItemInnerSpacing.x, 0 },
+            { "ItemInnerSpacing.y", StyleFloat, &ctx.style.ItemInnerSpacing.y, 0 },
+        { "CellPadding", StyleDropdownVec2, &ctx.style.CellPadding },
+            { "CellPadding.x", StyleFloat, &ctx.style.CellPadding.x, 0 },
+            { "CellPadding.y", StyleFloat, &ctx.style.CellPadding.y, 0 },
+        { "TouchExtraPadding", StyleDropdownVec2, &ctx.style.TouchExtraPadding },
+            { "TouchExtraPadding.x", StyleFloat, &ctx.style.TouchExtraPadding.x, 0 },
+            { "TouchExtraPadding.y", StyleFloat, &ctx.style.TouchExtraPadding.y, 0 },
+        { "IndentSpacing", StyleFloat, &ctx.style.IndentSpacing, 0 },
+        { "ColumnsMinSpacing", StyleFloat, &ctx.style.ColumnsMinSpacing, 0 },
+        { "ScrollbarSize", StyleFloat, &ctx.style.ScrollbarSize, 0 },
+        { "ScrollbarRounding", StyleFloat, &ctx.style.ScrollbarRounding, 0 },
+        { "ScrollbarPadding", StyleFloat, &ctx.style.ScrollbarPadding, 0 },
+        { "GrabMinSize", StyleFloat, &ctx.style.GrabMinSize, 0 },
+        { "GrabRounding", StyleFloat, &ctx.style.GrabRounding, 0 },
+        { "ImageBorderSize", StyleYesNo, &ctx.style.ImageBorderSize },
+        { "TabRounding", StyleFloat, &ctx.style.TabRounding },
+        { "TabBorderSize", StyleFloat, &ctx.style.TabBorderSize, 0 }, // StyleYesNo?
+        { "TabMinWidthBase", StyleFloat, &ctx.style.TabMinWidthBase, -1 },
+        { "TabMinWidthShrink", StyleFloat, &ctx.style.TabMinWidthShrink, -1 },
+        { "TabCloseButtonMinWidthSelected", StyleFloat, &ctx.style.TabCloseButtonMinWidthSelected, -1 },
+        { "TabCloseButtonMinWidthUnselected", StyleFloat, &ctx.style.TabCloseButtonMinWidthUnselected, -1 },
+        { "TabBarBorderSize", StyleYesNo, &ctx.style.TabBarBorderSize },
+        { "TabBarOverlineSize", StyleYesNo, &ctx.style.TabBarOverlineSize },
+        { "TreeLinesSize", StyleFloat, &ctx.style.TreeLinesSize, 0 },
+        { "TreeLinesRounding", StyleFloat, &ctx.style.TreeLinesRounding, 0 },
+        { "ButtonTextAlign", StyleDropdownVec2, &ctx.style.ButtonTextAlign },
+            { "ButtonTextAlign.x", StyleFloat, &ctx.style.ButtonTextAlign.x, 0, 1 },
+            { "ButtonTextAlign.y", StyleFloat, &ctx.style.ButtonTextAlign.y, 0, 1 },
+        { "SelectableTextAlign", StyleDropdownVec2, &ctx.style.SelectableTextAlign },
+            { "SelectableTextAlign.x", StyleFloat, &ctx.style.SelectableTextAlign.x, 0, 1 },
+            { "SelectableTextAlign.y", StyleFloat, &ctx.style.SelectableTextAlign.y, 0, 1 },
+        { "SeparatorTextBorderSize", StyleFloat, &ctx.style.SeparatorTextBorderSize, 0 },
+        { "SeparatorTextAlign", StyleDropdownVec2, &ctx.style.SeparatorTextAlign },
+            { "SeparatorTextAlign.x", StyleFloat, &ctx.style.SeparatorTextAlign.x, 0, 1 },
+            { "SeparatorTextAlign.y", StyleFloat, &ctx.style.SeparatorTextAlign.y, 0, 1 },
+        { "SeparatorTextPadding", StyleDropdownVec2, &ctx.style.SeparatorTextPadding },
+            { "SeparatorTextPadding.x", StyleFloat, &ctx.style.SeparatorTextPadding.x, 0 },
+            { "SeparatorTextPadding.y", StyleFloat, &ctx.style.SeparatorTextPadding.y, 0 },
+    };
+    std::string id = "##_" + std::string(attributes[i].name);
 
     // Generic
-    ImGui::Text("%s", names[i]);
+    ImGui::Text("%s", attributes[i].name);
     ImGui::TableNextColumn();
     ImGui::SetNextItemWidth(-1);
 
-    // Colors
-    if (i <= 59)
+    // Do the thing
+    float step = (attributes[i].max - attributes[i].min) / 250.f;
+    switch (attributes[i].type)
     {
-        ImGuiColorEditFlags flags = ImGui::GetContentRegionAvail().x < 200 ? ImGuiColorEditFlags_NoInputs : 0;
-        changed = ImGui::ColorEdit4(id.c_str(), (float*)&ctx.style.Colors[i], flags);
-    }
+    case StyleDropdownVec2:
+        ImGui::PushFont(true ? ctx.pgbFont : ctx.pgFont);
+        ImGui::Text("%d, %d", (int)((ImVec2*)attributes[i].value)->x, (int)((ImVec2*)attributes[i].value)->y);
+        ImGui::PopFont();
+        break;
+    case StyleColor:
+        changed = ImGui::ColorEdit4(id.c_str(), (float*)attributes[i].value, ImGui::GetContentRegionAvail().x < 200 ? ImGuiColorEditFlags_NoInputs : 0);
+        break;
+    case StyleFloat:
+        changed = ImGui::DragFloat(id.c_str(), (float*)attributes[i].value, step, attributes[i].min, attributes[i].max);
+        break;
+    case StyleYesNo:
+        changed = ImGui::DragFloat(id.c_str(), (float*)attributes[i].value, 1.f, 0.f, 1.f);
+    default:
+        break;
+    };
     return changed;
 }
 

--- a/src/node_standard.cpp
+++ b/src/node_standard.cpp
@@ -2874,25 +2874,146 @@ UINode::Style(UIContext& ctx)
     return {
         { "color.text", NULL },
         { "color.textDisabled", NULL },
+        { "color.windowBg", NULL },
+        { "color.childBg", NULL },
+        { "color.popupBg", NULL },
+        { "color.border", NULL },
+        { "color.borderShadow", NULL },
+        { "color.frameBg", NULL },
+        { "color.frameBgHovered", NULL },
+        { "color.frameBgActive", NULL },
+        { "color.titleBg", NULL },
+        { "color.titleBgActive", NULL },
+        { "color.titleBgCollapsed", NULL },
+        { "color.menuBarBg", NULL },
+        { "color.scrollbarBg", NULL },
+        { "color.scrollbarGrab", NULL },
+        { "color.scrollbarGrabHovered", NULL },
+        { "color.scrollbarGrabActive", NULL },
+        { "color.checkMark", NULL },
+        { "color.sliderGrab", NULL },
+        { "color.sliderGrabActive", NULL },
+        { "color.button", NULL },
+        { "color.buttonHovered", NULL },
+        { "color.buttonActive", NULL },
+        { "color.header", NULL },
+        { "color.headerHovered", NULL },
+        { "color.headerActive", NULL },
+        { "color.separator", NULL },
+        { "color.separatorHovered", NULL },
+        { "color.separatorActive", NULL },
+        { "color.resizeGrip", NULL },
+        { "color.resizeGripHovered", NULL },
+        { "color.resizeGripActive", NULL },
+        { "color.inputTextCursor", NULL },
+        { "color.tabHovered", NULL },
+        { "color.tab", NULL },
+        { "color.tabSelected", NULL },
+        { "color.tabSelectedOverline", NULL },
+        { "color.tabDimmed", NULL },
+        { "color.tabDimmedSelected", NULL },
+        { "color.tabDimmedSelectedOverline", NULL },
+        { "color.dockingPreview", NULL },
+        { "color.dockingEmptyBg", NULL },
+        { "color.plotLines", NULL },
+        { "color.plotLinesHovered", NULL },
+        { "color.plotHistogram", NULL },
+        { "color.plotHistogramHovered", NULL },
+        { "color.tableHeaderBg", NULL },
+        { "color.tableBorderStrong", NULL },
+        { "color.tableBorderLight", NULL },
+        { "color.tableRowBg", NULL },
+        { "color.tableRowBgAlt", NULL },
+        { "color.textLink", NULL },
+        { "color.textSelectedBg", NULL },
+        { "color.treeLines", NULL },
+        { "color.dragDropTarget", NULL },
+        { "color.navCursor", NULL },
+        { "color.navWindowingHighlight", NULL },
+        { "color.navWindowingDimBg", NULL },
+        { "color.modalWindowDimBg", NULL }
     };
 }
 
 bool UINode::StyleUI(int i, UIContext& ctx)
 {
     bool changed = false;
-    if (!i)
+    
+    // Name & ID
+    const char* names[] = {
+        "Text",
+        "TextDisabled",
+        "WindowBg",
+        "ChildBg",
+        "PopupBg",
+        "Border",
+        "BorderShadow",
+        "FrameBg",
+        "FrameBgHovered",
+        "FrameBgActive",
+        "TitleBg",
+        "TitleBgActive",
+        "TitleBgCollapsed",
+        "MenuBarBg",
+        "ScrollbarBg",
+        "ScrollbarGrab",
+        "ScrollbarGrabHovered",
+        "ScrollbarGrabActive",
+        "CheckMark",
+        "SliderGrab",
+        "SliderGrabActive",
+        "Button",
+        "ButtonHovered",
+        "ButtonActive",
+        "Header",
+        "HeaderHovered",
+        "HeaderActive",
+        "Separator",
+        "SeparatorHovered",
+        "SeparatorActive",
+        "ResizeGrip",
+        "ResizeGripHovered",
+        "ResizeGripActive",
+        "InputTextCursor",
+        "TabHovered",
+        "Tab",
+        "TabSelected",
+        "TabSelectedOverline",
+        "TabDimmed",
+        "TabDimmedSelected",
+        "TabDimmedSelectedOverline",
+        "DockingPreview",
+        "DockingEmptyBg",
+        "PlotLines",
+        "PlotLinesHovered",
+        "PlotHistogram",
+        "PlotHistogramHovered",
+        "TableHeaderBg",
+        "TableBorderStrong",
+        "TableBorderLight",
+        "TableRowBg",
+        "TableRowBgAlt",
+        "TextLink",
+        "TextSelectedBg",
+        "TreeLines",
+        "DragDropTarget",
+        "NavCursor",
+        "NavWindowingHighlight",
+        "NavWindowingDimBg",
+        "ModalWindowDimBg",
+    };
+    std::string id = "##_" + std::string(names[i]);
+
+    // Generic
+    ImGui::Text("%s", names[i]);
+    ImGui::TableNextColumn();
+    ImGui::SetNextItemWidth(-1);
+
+    // Colors
+    if (i <= 59)
     {
-        ImGui::Text("Text");
-        ImGui::TableNextColumn();
-        ImGui::SetNextItemWidth(-1);
-        changed = ImGui::ColorEdit4("##_ColorText", (float*)&ctx.style.Colors[ImGuiCol_Text]);
-    }
-    else
-    {
-        ImGui::Text("Disabled Text");
-        ImGui::TableNextColumn();
-        ImGui::SetNextItemWidth(-1);
-        changed = ImGui::ColorEdit4("##_ColorTextDisabled", (float*)&ctx.style.Colors[ImGuiCol_TextDisabled]);
+        ImGuiColorEditFlags flags = ImGui::GetContentRegionAvail().x < 200 ? ImGuiColorEditFlags_NoInputs : 0;
+        changed = ImGui::ColorEdit4(id.c_str(), (float*)&ctx.style.Colors[i], flags);
     }
     return changed;
 }

--- a/src/node_standard.h
+++ b/src/node_standard.h
@@ -56,8 +56,10 @@ struct UINode
     virtual void TreeUI(UIContext& ctx) = 0;
     virtual auto Properties()->std::vector<Prop> = 0;
     virtual auto Events()->std::vector<Prop> = 0;
+    virtual auto Style(UIContext& ctx) -> std::vector<Prop>;
     virtual bool PropertyUI(int, UIContext& ctx) = 0;
     virtual bool EventUI(int, UIContext& ctx) = 0;
+    virtual bool StyleUI(int, UIContext& ctx);
     virtual void Export(std::ostream&, UIContext& ctx) = 0;
     virtual void Import(cpp::stmt_iterator& sit, UIContext& ctx) = 0;
     virtual int Behavior() = 0;


### PR DESCRIPTION
# Description
Adds a style editor directly to the editor, so you don't need to open a separate text editor to modify styles. Changes are applied live, instead of needing to refresh the style to see differences. The style saves with the rest of the project, e.g. via Ctrl+S or the save button.

Also fixes a compilation error I was experiencing on GCC 14.2.0 from a missing `#include <algorithm>`.

# Considerations
- I did my best to make the style editor window match the appearance of the events/properties windows, but the actual editing widgets (specifically the color picker) can probably be improved.
- May be beneficial to reorder/categorize the style elements into more than just color/style categories.
- Currently, switching styles/tabs will cause unsaved style changes to be discarded. It may be useful to add a warning popup beforehand.
- This likely makes the existing `Edit Style` button redundant, could be removed or repurposed to something like `Open Style Folder`.

Additional feedback would be appreciated!

# Images
<img width="3088" height="1938" alt="Screenshot_20260105_164826" src="https://github.com/user-attachments/assets/055616ad-52f8-4fc8-b172-9a052e9d0b9f" />
<img alt="untitled-2" src="https://github.com/user-attachments/assets/f40591dd-2a8a-4938-8e52-c8a59bf07842" />